### PR TITLE
Append to a base wpa_supplicant.conf instead of rewriting it from scratch

### DIFF
--- a/libs/configuration_app/app.py
+++ b/libs/configuration_app/app.py
@@ -47,11 +47,10 @@ def scan_wifi_networks():
     return ap_array
 
 def create_wpa_supplicant(ssid, wifi_key):
-    temp_conf_file = open('wpa_supplicant.conf.tmp', 'w')
-
-    temp_conf_file.write('ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev\n')
-    temp_conf_file.write('update_config=1\n')
-    temp_conf_file.write('\n')
+    os.system('cp /etc/wpa_supplicant/wpa_supplicant.conf.base wpa_supplicant.conf.tmp')
+    
+    temp_conf_file = open('wpa_supplicant.conf.tmp', 'a')
+    
     temp_conf_file.write('network={\n')
     temp_conf_file.write('	ssid="' + ssid + '"\n')
 

--- a/setup_lib.py
+++ b/setup_lib.py
@@ -15,7 +15,7 @@ def copy_configs():
 	os.system('mkdir /usr/lib/raspiwifi')
 	os.system('mkdir /etc/raspiwifi')
 	os.system('cp -a libs/* /usr/lib/raspiwifi/')
-	os.system('rm -f /etc/wpa_supplicant/wpa_supplicant.conf')
+	os.system('mv /etc/wpa_supplicant/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf.base')
 	os.system('rm -f ./tmp/*')
 	os.system('mv /etc/dnsmasq.conf /etc/dnsmasq.conf.original')
 	os.system('cp /usr/lib/raspiwifi/reset_device/static_files/dnsmasq.conf /etc/')


### PR DESCRIPTION
This pull request implements #51  by copying the initial wpa_supplicant.conf to wpa_supplicant.conf.base and then re-using it as a base template whenever adding a new network.