### PR TITLE
implements fix on issue 56

### DIFF
--- a/libs/configuration_app/app.py
+++ b/libs/configuration_app/app.py
@@ -76,6 +76,7 @@ def create_wpa_supplicant(ssid, wifi_key):
     os.system('mv wpa_supplicant.conf.tmp /etc/wpa_supplicant/wpa_supplicant.conf')
 
 def set_ap_client_mode():
+    os.system('rm -f /etc/raspiwifi/host_mode')
     os.system('rm /etc/cron.raspiwifi/aphost_bootstrapper')
     os.system('cp /usr/lib/raspiwifi/reset_device/static_files/apclient_bootstrapper /etc/cron.raspiwifi/')
     os.system('chmod +x /etc/cron.raspiwifi/apclient_bootstrapper')

--- a/libs/reset_device/reset_lib.py
+++ b/libs/reset_device/reset_lib.py
@@ -41,15 +41,17 @@ def is_wifi_active():
 	return wifi_active
 
 def reset_to_host_mode():
-	os.system('aplay /usr/lib/raspiwifi/reset_device/button_chime.wav')
-	os.system('rm -f /etc/wpa_supplicant/wpa_supplicant.conf')
-	os.system('rm -f /home/pi/Projects/RaspiWifi/tmp/*')
-	os.system('rm /etc/cron.raspiwifi/apclient_bootstrapper')
-	os.system('cp /usr/lib/raspiwifi/reset_device/static_files/aphost_bootstrapper /etc/cron.raspiwifi/')
-	os.system('chmod +x /etc/cron.raspiwifi/aphost_bootstrapper')
-	os.system('mv /etc/dhcpcd.conf /etc/dhcpcd.conf.original')
-	os.system('cp /usr/lib/raspiwifi/reset_device/static_files/dhcpcd.conf /etc/')
-	os.system('mv /etc/dnsmasq.conf /etc/dnsmasq.conf.original')
-	os.system('cp /usr/lib/raspiwifi/reset_device/static_files/dnsmasq.conf /etc/')
-	os.system('cp /usr/lib/raspiwifi/reset_device/static_files/dhcpcd.conf /etc/')
+	if not os.path.isfile('/etc/raspiwifi/host_mode'):
+		os.system('aplay /usr/lib/raspiwifi/reset_device/button_chime.wav')
+		os.system('rm -f /etc/wpa_supplicant/wpa_supplicant.conf')
+		os.system('rm -f /home/pi/Projects/RaspiWifi/tmp/*')
+		os.system('rm /etc/cron.raspiwifi/apclient_bootstrapper')
+		os.system('cp /usr/lib/raspiwifi/reset_device/static_files/aphost_bootstrapper /etc/cron.raspiwifi/')
+		os.system('chmod +x /etc/cron.raspiwifi/aphost_bootstrapper')
+		os.system('mv /etc/dhcpcd.conf /etc/dhcpcd.conf.original')
+		os.system('cp /usr/lib/raspiwifi/reset_device/static_files/dhcpcd.conf /etc/')
+		os.system('mv /etc/dnsmasq.conf /etc/dnsmasq.conf.original')
+		os.system('cp /usr/lib/raspiwifi/reset_device/static_files/dnsmasq.conf /etc/')
+		os.system('cp /usr/lib/raspiwifi/reset_device/static_files/dhcpcd.conf /etc/')
+		os.system('touch /etc/raspiwifi/host_mode')
 	os.system('reboot')


### PR DESCRIPTION
dirt fix.

- creates "/etc/raspiwifi/host_mode" when entering host_mode.
- if file exists, holding the GPO 18 high for 10 seconds only restarts the raspberry, does not sets the configuration again.
- removes "/etc/raspiwifi/host_mode" file after entering ap client mode