### PR TITLE
Update reset.py to correct serial

### DIFF
--- a/libs/reset_device/reset.py
+++ b/libs/reset_device/reset.py
@@ -8,7 +8,7 @@ GPIO.setmode(GPIO.BCM)
 GPIO.setup(18, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
 
 counter = 0
-serial_last_four = subprocess.check_output(['cat', '/proc/cpuinfo'])[-5:-1].decode('utf-8')
+serial_last_four = subprocess.check_output(['cat', '/sys/firmware/devicetree/base/serial-number'])[-5:-1].decode('utf-8')
 config_hash = reset_lib.config_file_hash()
 ssid_prefix = config_hash['ssid_prefix'] + " "
 reboot_required = False


### PR DESCRIPTION
The previous command (cat /proc/cpuinfo) was incorrect, because the last line is the "Model" description, and not serial.
With the command I wrote, it will always be serial number.
Works on at least RPi 2,3B,3B+,4.
See https://raspberrypi.stackexchange.com/a/106501